### PR TITLE
Update k8s.py

### DIFF
--- a/leaderelection/k8s.py
+++ b/leaderelection/k8s.py
@@ -2,7 +2,7 @@ import os
 import yaml
 import time
 import logging
-from datetime import datetime
+from datetime import datetime, timedelta
 from kubernetes import client
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
Exception in thread Thread-1:
Traceback (most recent call last):
  File "/usr/local/lib/python3.7/threading.py", line 926, in _bootstrap_inner
    self.run()
  File "/usr/local/lib/python3.7/threading.py", line 870, in run
    self._target(*self._args, **self._kwargs)
  File "/usr/local/lib/python3.7/site-packages/leaderelection/main.py", line 37, in run
    poll_configmap(self.coreV1Api, self.namespace, self.configmap, self.pod, self.pollDelaySeconds, self.leaseDurationSeconds)
  File "/usr/local/lib/python3.7/site-packages/leaderelection/k8s.py", line 51, in poll_configmap
    elif cmap.data['timestamp'] + timedelta(seconds=leaseDurationSeconds) < timestamp:
NameError: name 'timedelta' is not defined